### PR TITLE
Fix "process.stdout.clearLine is not a function" error  and add minimal travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+
+dist: trusty
+
+language: bash
+
+services:
+  - docker
+
+before_install:
+  - docker -v
+
+script:
+  - docker build -t dev-trip-simulator -f Dockerfile-test .

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,47 @@
+FROM node:11
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    osmium-tool \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Prepare OSM input files
+RUN curl https://s3.amazonaws.com/metro-extracts.nextzen.org/nashville_tennessee.osm.pbf -o nashville.osm.pbf \
+    && osmium extract -b "-86.84881,36.12262,-86.73688,36.20494" nashville.osm.pbf -o ./nash.osm.pbf -s "complete_ways" --overwrite \
+    && rm nashville.osm.pbf \
+    && ls -la *.osm.pbf
+
+# Copy source code to Docker image
+COPY . /trip-simulator/
+RUN ls -la /trip-simulator/src/*
+
+
+WORKDIR /trip-simulator
+RUN npm install
+
+WORKDIR /trip-simulator/data
+
+# Build OSRM data
+RUN cp  /nash.osm.pbf .
+RUN /trip-simulator/node_modules/osrm/lib/binding/osrm-extract \
+        ./nash.osm.pbf \
+        -p /trip-simulator/node_modules/osrm/profiles/foot.lua
+RUN /trip-simulator/node_modules/osrm/lib/binding/osrm-contract ./nash.osrm
+
+# Start simulator
+RUN mkdir -p ./result \
+  && node /trip-simulator/src/cli.js \
+  --config scooter \
+  --pbf nash.osm.pbf \
+  --graph nash.osrm \
+  --agents 20 \
+  --start 1563122921000 \
+  --seconds 36000 \
+  --traces ./result/traces.json \
+  --probes ./result/probes.json \
+  --changes ./result/changes.json \
+  --trips ./result/trips.json
+
+# List "result" files ..
+RUN ls -la
+RUN ls -la ./result/*

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "osm-pbf-parser": "^2.3.0",
     "osrm": "^5.22.0",
     "random": "^2.0.13",
+    "readline": "^1.3.0",
     "through2": "^3.0.1"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const readline = require('readline');
 const path = require("path");
 const Simulation = require("./simulation");
 var argv = require("minimist")(process.argv.slice(2));
@@ -71,8 +72,8 @@ async function main() {
       const update = (((seconds - i) / seconds) * 100).toFixed(2) + "%";
       if (update !== message) {
         message = update;
-        process.stdout.clearLine();
-        process.stdout.cursorTo(0);
+        readline.clearLine(process.stdout)
+        readline.cursorTo(process.stdout, 0)
         process.stdout.write(message);
       }
     }


### PR DESCRIPTION
Thank you for this tool!

I don't know - this code should work on 'node:11' - but I have receiving this error message: 
 
```
(node:7) UnhandledPromiseRejectionWarning: TypeError: process.stdout.clearLine is not a function
    at main (/trip-simulator/src/cli.js:74:24)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
(node:7) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:7) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I have created a fix ; and added a minimal `Docker_test`  files - for travis testing ( based on your readme )
* https://travis-ci.org/ImreSamu/trip-simulator/builds/567550589

You can change / modify / drop  - this pull request -  as you like :) 
